### PR TITLE
Feat: 버튼 공통 컴포넌트 추가

### DIFF
--- a/src/components/Cart/Estimate/index.tsx
+++ b/src/components/Cart/Estimate/index.tsx
@@ -6,6 +6,7 @@ import calculateTotalPrice from "../../../utils/calculateTotalPrice";
 import formatNumber from "../../../utils/formatNumber";
 import * as Styled from "./Estimate.styles";
 import { EstimateProps } from "./Estimate.types";
+import Button from "../../Common/Button";
 import { handleBuyClick } from "./Estimate.utils";
 
 const Estimate = ({ estimatedPrice }: EstimateProps) => {
@@ -40,15 +41,17 @@ const Estimate = ({ estimatedPrice }: EstimateProps) => {
         <Styled.Empty />
         <span>{formatNumber(totalPrice)}원</span>
       </Styled.Bottom>
-      <Styled.Button
+      <Button
+        text="구매하기"
+        type="orange"
+        size="lg"
+        style={{ width: "100%" }}
         onClick={() => {
           handleBuyClick(estimatedPrice, setPurchaseList);
           if (estimatedPrice.length > 0) navigate("/payment");
           else alert("선택해주세요");
         }}
-      >
-        구매하기
-      </Styled.Button>
+      />
     </Styled.Container>
   );
 };

--- a/src/components/Common/Button.tsx
+++ b/src/components/Common/Button.tsx
@@ -1,0 +1,90 @@
+/** @jsxImportSource @emotion/react */
+
+import { CSSProperties, ReactNode } from "react";
+
+interface ButtonProps {
+  text: string;
+  type: string;
+  size: string;
+  onClick: (evnet: React.MouseEvent) => void;
+  children?: ReactNode;
+  style?: CSSProperties;
+}
+
+interface Theme {
+  default: string;
+  blue: string;
+  orange: string;
+  [key: string]: string;
+}
+
+interface SizeTheme {
+  [size: string]: {
+    fontSize: string;
+    padding: string;
+  };
+}
+
+const border: Theme = {
+  default: "1px solid #E6E6E6",
+  blue: "1px solid #001650",
+  orange: "1px solid #FF5100",
+};
+
+const color: Theme = {
+  default: "#222",
+  blue: "#001650",
+  orange: "#fff",
+};
+
+const bg: Theme = {
+  default: "#fff",
+  blue: "#fff",
+  orange: "#FF5100",
+};
+
+const sizeStyle: SizeTheme = {
+  sm: {
+    fontSize: "12px",
+    padding: "3px 12px",
+  },
+  md: {
+    fontSize: "14px",
+    padding: "5px 16px",
+  },
+  lg: {
+    fontSize: "16px",
+    padding: "9px 20px",
+  },
+};
+
+const Button = ({
+  text,
+  type,
+  size,
+  onClick,
+  children,
+  style,
+}: ButtonProps) => {
+  return (
+    <button
+      css={{
+        borderRadius: "3px",
+        border: border[type],
+        backgroundColor: bg[type],
+        color: color[type],
+        ...sizeStyle[size],
+        textAlign: "center",
+        cursor: "pointer",
+        appearance: "none",
+        userSelect: "none",
+        ...style,
+      }}
+      onClick={onClick}
+    >
+      {children || text}
+    </button>
+  );
+};
+
+export default Button;


### PR DESCRIPTION
## Issue Number
#10 
클로즈(X)
## ETC
진짜 기본적인 스타일링만 들어가 있습니다. 버튼에 대한 추가 기능이나 스타일 필요 시 해당 파일에서 직접 수정해주셔도 됩니다!!

### 공통 버튼 컴포넌트 사용

```javascript
<Button
  text="구매하기" // *필수
  type="orange" // default, blue, orange 3가지 구성 - 현재 디자인 반영 *필수
  size="lg" // sm, md, lg 3가지 구성 - 이후 필요 시 수정 가능 *필수
  style={{ width: "100%" }} // 필요한 스타일 추가 지정 *옵션
  onClick={() => {
     // 클릭 로직
   }}
/>
```
1. orange
![스크린샷 2023-11-22 152743](https://github.com/Yanolza-Miniproject/frontend/assets/125336070/3ad37ee5-6073-4fb2-910c-183910ff9a5e)

2. blue
![스크린샷 2023-11-22 152817](https://github.com/Yanolza-Miniproject/frontend/assets/125336070/b6cc013c-6458-405a-b871-de116297305c)

3. default
![스크린샷 2023-11-22 152807](https://github.com/Yanolza-Miniproject/frontend/assets/125336070/4b3bb0e4-a9e1-406f-944a-4b8cb336acfe)
