### PR TITLE
Feat: 결제페이지, 마이페이지, 결제내역페이지 레이아웃 제작

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import Complete from "./pages/Complete";
 import Detail from "./pages/Detail";
 import Main from "./pages/Main";
 import MyPage from "./pages/MyPage";
+import MyOrder from "./pages/MyPage/MyOrder";
 import NotFound from "./pages/NotFound";
 import Payment from "./pages/Payment";
 import Signin from "./pages/Signin";
@@ -23,6 +24,7 @@ const router = createBrowserRouter([
       { path: "payment", element: <Payment /> },
       { path: "complete", element: <Complete /> },
       { path: "mypage", element: <MyPage /> },
+      { path: "mypage/myorder", element: <MyOrder /> },
     ],
   },
   {

--- a/src/assets/arrow.svg
+++ b/src/assets/arrow.svg
@@ -1,0 +1,3 @@
+<svg width="15" height="29" viewBox="0 0 15 29" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path id="Vector 11" d="M1 1L14.0909 14.5L1 28" stroke="#646464" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/MyPage/Header/Header.styles.ts
+++ b/src/components/MyPage/Header/Header.styles.ts
@@ -1,0 +1,23 @@
+import styled from "@emotion/styled";
+
+export const Header = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+export const Profile = styled.div`
+  display: flex;
+`;
+export const UserName = styled.div`
+  color: #ff5100;
+  font-size: 1.125rem;
+  font-weight: 600;
+`;
+
+export const LeaveBtn = styled.div`
+  color: #646464;
+
+  font-size: 0.875rem;
+  font-weight: 500;
+  text-decoration-line: underline;
+`;

--- a/src/components/MyPage/Header/index.tsx
+++ b/src/components/MyPage/Header/index.tsx
@@ -1,0 +1,15 @@
+import * as Styled from "./Header.styles";
+
+const index = () => {
+  return (
+    <Styled.Header>
+      <Styled.Profile>
+        <Styled.UserName>test1234</Styled.UserName>
+        <span>님 안녕하세요!</span>
+      </Styled.Profile>
+      <Styled.LeaveBtn>탈퇴하기</Styled.LeaveBtn>
+    </Styled.Header>
+  );
+};
+
+export default index;

--- a/src/components/MyPage/MyList/MyList.styles.ts
+++ b/src/components/MyPage/MyList/MyList.styles.ts
@@ -1,0 +1,50 @@
+import styled from "@emotion/styled";
+
+export const MyList = styled.div`
+  margin-top: 2.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+
+  width: 100%;
+`;
+
+export const MyBox = styled.div`
+  display: flex;
+  text-align: center;
+  align-items: center;
+  justify-content: space-between;
+
+  width: 100%;
+  border-radius: 0.625rem;
+  border: 1px solid #e6e6e6;
+  background: #fff;
+  padding: 3rem 3.12rem;
+  box-sizing: border-box;
+
+  cursor: pointer;
+  &:hover {
+    border: 1px solid #ff5100;
+    box-shadow: 0px 0px 20px 0px rgba(255, 81, 0, 0.05);
+  }
+`;
+
+export const Content = styled.div`
+  display: flex;
+  text-align: center;
+  align-items: center;
+`;
+
+export const Title = styled.div`
+  color: #222;
+  font-size: 1.75rem;
+  font-weight: 400;
+  margin-right: 3.5rem;
+`;
+
+export const Count = styled.div`
+  color: #222;
+  font-size: 1.875rem;
+  font-weight: 600;
+  line-height: 2.625rem;
+`;

--- a/src/components/MyPage/MyList/index.tsx
+++ b/src/components/MyPage/MyList/index.tsx
@@ -1,30 +1,37 @@
+import { Link } from "react-router-dom";
 import Arrow from "../../../assets/arrow.svg";
 import * as Styled from "./MyList.styles";
 
 const index = () => {
   return (
     <Styled.MyList>
+      <Link to="/mypage/myorder" style={{ textDecoration: "none" }}>
+        <Styled.MyBox>
+          <Styled.Content>
+            <Styled.Title>💵 결제 내역</Styled.Title>
+            <Styled.Count>3</Styled.Count>
+          </Styled.Content>
+          <img src={Arrow}></img>
+        </Styled.MyBox>
+      </Link>
+      <Link to="/cart" style={{ textDecoration: "none" }}>
+        <Styled.MyBox>
+          <Styled.Content>
+            <Styled.Title>🛒 장바구니</Styled.Title>
+            <Styled.Count>3</Styled.Count>
+          </Styled.Content>
+          <img src={Arrow}></img>
+        </Styled.MyBox>
+      </Link>
+      {/* <Link to="/wish"> */}
       <Styled.MyBox>
         <Styled.Content>
-          <Styled.Title>💵 결제 내역</Styled.Title>
+          <Styled.Title>❤️ 찜한 목록</Styled.Title>
           <Styled.Count>3</Styled.Count>
         </Styled.Content>
         <img src={Arrow}></img>
       </Styled.MyBox>
-      <Styled.MyBox>
-        <Styled.Content>
-          <Styled.Title>🛒 장바구니</Styled.Title>
-          <Styled.Count>3</Styled.Count>
-        </Styled.Content>
-        <img src={Arrow}></img>
-      </Styled.MyBox>
-      <Styled.MyBox>
-        <Styled.Content>
-          <Styled.Title>❤️ 결제 내역</Styled.Title>
-          <Styled.Count>3</Styled.Count>
-        </Styled.Content>
-        <img src={Arrow}></img>
-      </Styled.MyBox>
+      {/* </Link> */}
     </Styled.MyList>
   );
 };

--- a/src/components/MyPage/MyList/index.tsx
+++ b/src/components/MyPage/MyList/index.tsx
@@ -1,0 +1,32 @@
+import Arrow from "../../../assets/arrow.svg";
+import * as Styled from "./MyList.styles";
+
+const index = () => {
+  return (
+    <Styled.MyList>
+      <Styled.MyBox>
+        <Styled.Content>
+          <Styled.Title>💵 결제 내역</Styled.Title>
+          <Styled.Count>3</Styled.Count>
+        </Styled.Content>
+        <img src={Arrow}></img>
+      </Styled.MyBox>
+      <Styled.MyBox>
+        <Styled.Content>
+          <Styled.Title>🛒 장바구니</Styled.Title>
+          <Styled.Count>3</Styled.Count>
+        </Styled.Content>
+        <img src={Arrow}></img>
+      </Styled.MyBox>
+      <Styled.MyBox>
+        <Styled.Content>
+          <Styled.Title>❤️ 결제 내역</Styled.Title>
+          <Styled.Count>3</Styled.Count>
+        </Styled.Content>
+        <img src={Arrow}></img>
+      </Styled.MyBox>
+    </Styled.MyList>
+  );
+};
+
+export default index;

--- a/src/components/MyPage/MyOrder/Header/Header.styles.ts
+++ b/src/components/MyPage/MyOrder/Header/Header.styles.ts
@@ -1,0 +1,22 @@
+import styled from "@emotion/styled";
+
+export const Header = styled.span`
+  color: #222;
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: -0.05rem;
+
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  text-align: center;
+`;
+
+export const BackToMyPageBtn = styled.span`
+  color: #646464;
+
+  font-size: 0.875rem;
+  font-weight: 500;
+  letter-spacing: -0.05rem;
+  text-decoration-line: underline;
+`;

--- a/src/components/MyPage/MyOrder/Header/index.tsx
+++ b/src/components/MyPage/MyOrder/Header/index.tsx
@@ -1,0 +1,15 @@
+import { Link } from "react-router-dom";
+import * as Styled from "./Header.styles";
+
+const index = () => {
+  return (
+    <Styled.Header>
+      <span>결제내역</span>
+      <Link to="/mypage" style={{ textDecoration: "none" }}>
+        <Styled.BackToMyPageBtn>돌아가기</Styled.BackToMyPageBtn>
+      </Link>
+    </Styled.Header>
+  );
+};
+
+export default index;

--- a/src/components/MyPage/MyOrder/MyOrderItem/MyOrder.styles.ts
+++ b/src/components/MyPage/MyOrder/MyOrderItem/MyOrder.styles.ts
@@ -1,0 +1,69 @@
+import styled from "@emotion/styled";
+
+export const ItemWrapper = styled.ul`
+  position: relative;
+  border-radius: 0.625rem;
+  border: 1px solid #e6e6e6;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+  padding: 1.19rem 0.81rem 2.19rem 2.81rem;
+
+  cursor: pointer;
+  &:hover {
+    border: 1px solid #ff5100;
+    box-shadow: 0px 0px 20px 0px rgba(255, 81, 0, 0.05);
+  }
+`;
+
+export const ItemTitle = styled.p`
+  color: #222;
+  font-size: 1.125rem;
+  font-weight: 700;
+  line-height: normal;
+  letter-spacing: -0.05625rem;
+`;
+
+export const ItemContent = styled.div`
+  display: flex;
+`;
+
+export const ItemInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+`;
+
+export const ItemValueWrapper = styled.div``;
+
+export const Title = styled.span`
+  color: #222;
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: normal;
+  letter-spacing: -0.05rem;
+`;
+
+export const ItemImg = styled.div`
+  width: 8.25rem;
+  height: 8.5625rem;
+  background: #d9d9d9;
+  margin-right: 1.81rem;
+`;
+
+export const Content = styled.span``;
+
+export const ItemHeadCount = styled.span``;
+
+export const ItemPriceWrapper = styled.div`
+  position: absolute;
+  right: 3%;
+  bottom: 10%;
+
+  color: #222;
+  font-size: 1.125rem;
+  font-weight: 700;
+  letter-spacing: -0.05625rem;
+`;
+
+export const ItemPrice = styled.span``;

--- a/src/components/MyPage/MyOrder/MyOrderItem/index.tsx
+++ b/src/components/MyPage/MyOrder/MyOrderItem/index.tsx
@@ -1,0 +1,33 @@
+import * as Styled from "./MyOrder.styles";
+
+const index = () => {
+  return (
+    <Styled.ItemWrapper>
+      <Styled.ItemTitle>제주도 호텔</Styled.ItemTitle>
+      <Styled.ItemContent>
+        <Styled.ItemImg></Styled.ItemImg>
+        <Styled.ItemInfo>
+          <Styled.ItemValueWrapper>
+            <Styled.Title>방 타입: </Styled.Title>
+            <Styled.Content>디럭스 룸</Styled.Content>
+          </Styled.ItemValueWrapper>
+          <Styled.ItemValueWrapper>
+            <Styled.Title>숙박일: </Styled.Title>
+            <Styled.Content>2023.11.11(월) ~ 2023.11.15(금) </Styled.Content>
+            <Styled.Content> | 3박</Styled.Content>
+          </Styled.ItemValueWrapper>
+          <Styled.ItemValueWrapper>
+            <Styled.Title>숙박인원: </Styled.Title>
+            <Styled.Content>3 </Styled.Content>
+          </Styled.ItemValueWrapper>
+        </Styled.ItemInfo>
+      </Styled.ItemContent>
+      <Styled.ItemPriceWrapper>
+        <span>₩</span>
+        <Styled.ItemPrice>39,000</Styled.ItemPrice>
+      </Styled.ItemPriceWrapper>
+    </Styled.ItemWrapper>
+  );
+};
+
+export default index;

--- a/src/components/MyPage/MyOrder/MyOrderList/MyOrderList.styles.ts
+++ b/src/components/MyPage/MyOrder/MyOrderList/MyOrderList.styles.ts
@@ -1,0 +1,6 @@
+import styled from "@emotion/styled";
+
+export const MyOrderList = styled.li`
+  list-style: none;
+  overflow: auto;
+`;

--- a/src/components/MyPage/MyOrder/MyOrderList/index.tsx
+++ b/src/components/MyPage/MyOrder/MyOrderList/index.tsx
@@ -1,0 +1,14 @@
+import MyOrderItem from "../MyOrderItem/index";
+import * as Styled from "./MyOrderList.styles";
+
+const index = () => {
+  return (
+    <Styled.MyOrderList>
+      <MyOrderItem />
+      <MyOrderItem />
+      <MyOrderItem />
+    </Styled.MyOrderList>
+  );
+};
+
+export default index;

--- a/src/components/Payment/Btn/Btn.styles.ts
+++ b/src/components/Payment/Btn/Btn.styles.ts
@@ -1,0 +1,63 @@
+import styled from "@emotion/styled";
+
+export const BtnWrapper = styled.div`
+  position: absolute;
+  right: 0%;
+  display: flex;
+  margin-top: 1.3rem;
+  gap: 0.63rem;
+`;
+
+export const BackToCart = styled.button`
+  width: 15.875rem;
+  height: 2.5rem;
+
+  background-color: #fff;
+  border: 1px solid #d3d3d3;
+  border-radius: 0.06;
+  text-align: center;
+  font-size: 0.9rem;
+  cursor: pointer;
+
+  &:hover {
+    border: 1px solid #ff5100;
+    color: #ff5100;
+  }
+`;
+
+export const GoToPay = styled.button`
+  width: 15.875rem;
+  height: 2.5rem;
+
+  background-color: #ff5100;
+  border: 1px solid #ff5100;
+  border-radius: 0.06;
+  text-align: center;
+  color: #fff;
+  font-size: 0.9rem;
+
+  display: flex;
+  text-align: center;
+  align-items: center;
+  justify-content: center;
+
+  cursor: pointer;
+
+  &:hover {
+    border: 1px solid #ff5100;
+    background-color: #fff;
+    color: #ff5100;
+  }
+`;
+
+export const ItemPriceWrapper = styled.div`
+  font-weight: 600;
+  display: flex;
+  text-align: center;
+  align-items: center;
+`;
+
+export const ItemPrice = styled.div`
+  width: 100%;
+  margin-right: 0.2rem;
+`;

--- a/src/components/Payment/Btn/index.tsx
+++ b/src/components/Payment/Btn/index.tsx
@@ -1,0 +1,18 @@
+import * as Styled from "./Btn.styles";
+
+const index = () => {
+  return (
+    <Styled.BtnWrapper>
+      <Styled.BackToCart>장바구니로 돌아가기</Styled.BackToCart>
+      <Styled.GoToPay>
+        <Styled.ItemPriceWrapper>
+          <span>₩</span>
+          <Styled.ItemPrice>39,000</Styled.ItemPrice>
+        </Styled.ItemPriceWrapper>
+        결제하기
+      </Styled.GoToPay>
+    </Styled.BtnWrapper>
+  );
+};
+
+export default index;

--- a/src/components/Payment/Item/Item.styles.ts
+++ b/src/components/Payment/Item/Item.styles.ts
@@ -1,0 +1,63 @@
+import styled from "@emotion/styled";
+
+export const ItemWrapper = styled.ul`
+  position: relative;
+  border-radius: 0.625rem;
+  border: 1px solid #e6e6e6;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+  padding: 1.19rem 0.81rem 2.19rem 2.81rem;
+`;
+
+export const ItemTitle = styled.p`
+  color: #222;
+  font-size: 1.125rem;
+  font-weight: 700;
+  line-height: normal;
+  letter-spacing: -0.05625rem;
+`;
+
+export const ItemContent = styled.div`
+  display: flex;
+`;
+
+export const ItemInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+`;
+
+export const ItemValueWrapper = styled.div``;
+
+export const Title = styled.span`
+  color: #222;
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: normal;
+  letter-spacing: -0.05rem;
+`;
+
+export const ItemImg = styled.div`
+  width: 8.25rem;
+  height: 8.5625rem;
+  background: #d9d9d9;
+  margin-right: 1.81rem;
+`;
+
+export const Content = styled.span``;
+
+export const ItemHeadCount = styled.span``;
+
+export const ItemPriceWrapper = styled.div`
+  position: absolute;
+  right: 3%;
+  bottom: 10%;
+
+  color: #222;
+  font-size: 1.125rem;
+  font-weight: 700;
+  letter-spacing: -0.05625rem;
+`;
+
+export const ItemPrice = styled.span``;

--- a/src/components/Payment/Item/index.tsx
+++ b/src/components/Payment/Item/index.tsx
@@ -1,0 +1,33 @@
+import * as Styled from "./Item.styles";
+
+const index = () => {
+  return (
+    <Styled.ItemWrapper>
+      <Styled.ItemTitle>제주도 호텔</Styled.ItemTitle>
+      <Styled.ItemContent>
+        <Styled.ItemImg></Styled.ItemImg>
+        <Styled.ItemInfo>
+          <Styled.ItemValueWrapper>
+            <Styled.Title>방 타입: </Styled.Title>
+            <Styled.Content>디럭스 룸</Styled.Content>
+          </Styled.ItemValueWrapper>
+          <Styled.ItemValueWrapper>
+            <Styled.Title>숙박일: </Styled.Title>
+            <Styled.Content>2023.11.11(월) ~ 2023.11.15(금) </Styled.Content>
+            <Styled.Content> | 3박</Styled.Content>
+          </Styled.ItemValueWrapper>
+          <Styled.ItemValueWrapper>
+            <Styled.Title>숙박인원: </Styled.Title>
+            <Styled.Content>3 </Styled.Content>
+          </Styled.ItemValueWrapper>
+        </Styled.ItemInfo>
+      </Styled.ItemContent>
+      <Styled.ItemPriceWrapper>
+        <span>₩</span>
+        <Styled.ItemPrice>39,000</Styled.ItemPrice>
+      </Styled.ItemPriceWrapper>
+    </Styled.ItemWrapper>
+  );
+};
+
+export default index;

--- a/src/components/Payment/ItemList/ItemList.styles.ts
+++ b/src/components/Payment/ItemList/ItemList.styles.ts
@@ -1,0 +1,10 @@
+import styled from "@emotion/styled";
+
+export const PaymentItemWrapper = styled.div`
+  width: 100%;
+  list-style: none;
+`;
+
+export const ItemList = styled.li`
+  width: 100%;
+`;

--- a/src/components/Payment/ItemList/index.tsx
+++ b/src/components/Payment/ItemList/index.tsx
@@ -1,0 +1,15 @@
+import Item from "../Item/index";
+import * as Styled from "./ItemList.styles";
+
+const index = () => {
+  return (
+    <Styled.PaymentItemWrapper>
+      <h3>결제 항목</h3>
+      <Styled.ItemList>
+        <Item />
+      </Styled.ItemList>
+    </Styled.PaymentItemWrapper>
+  );
+};
+
+export default index;

--- a/src/components/Payment/TermsAndConditions/TermsAndConditions.styles.ts
+++ b/src/components/Payment/TermsAndConditions/TermsAndConditions.styles.ts
@@ -1,0 +1,26 @@
+import styled from "@emotion/styled";
+
+export const TermsAndConditionsWrapper = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+
+  color: #4a4a4a;
+  font-size: 1rem;
+  font-weight: 500;
+  line-height: normal;
+  letter-spacing: -0.05rem;
+`;
+
+export const InputWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  width: 100%;
+`;
+
+export const label = styled.label`
+  width: 100%;
+  margin-top: 1rem;
+  margin-left: 1rem;
+`;

--- a/src/components/Payment/TermsAndConditions/index.tsx
+++ b/src/components/Payment/TermsAndConditions/index.tsx
@@ -1,0 +1,33 @@
+import * as Styled from "./TermsAndConditions.styles";
+
+const index = () => {
+  return (
+    <Styled.TermsAndConditionsWrapper>
+      <h3>약관 동의</h3>
+      <Styled.InputWrapper>
+        <label>
+          <input type="checkbox" />
+          필수 약관 전체 동의
+        </label>
+        <Styled.label>
+          <input type="checkbox" />
+          [필수] 만 14세 이상 이용 동의
+        </Styled.label>
+        <Styled.label>
+          <input type="checkbox" />
+          [필수] 개인정보 수집 및 이용
+        </Styled.label>
+        <Styled.label>
+          <input type="checkbox" />
+          [필수] 개인정보 제 3자 제공
+        </Styled.label>
+        <Styled.label>
+          <input type="checkbox" />
+          [선택] E-mail 및 SMS 광고성 정보 수신동의
+        </Styled.label>
+      </Styled.InputWrapper>
+    </Styled.TermsAndConditionsWrapper>
+  );
+};
+
+export default index;

--- a/src/components/Payment/TotalPrice/TotalPrice.styles.ts
+++ b/src/components/Payment/TotalPrice/TotalPrice.styles.ts
@@ -1,0 +1,21 @@
+import styled from "@emotion/styled";
+
+export const TotalPriceWrapper = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+export const ItemPriceWrapper = styled.div`
+  display: flex;
+`;
+
+export const ItemPrice = styled.div`
+  width: 100%;
+
+  color: #222;
+  font-size: 1.125rem;
+  font-weight: 700;
+  letter-spacing: -0.05625rem;
+`;

--- a/src/components/Payment/TotalPrice/index.tsx
+++ b/src/components/Payment/TotalPrice/index.tsx
@@ -1,0 +1,15 @@
+import * as Styled from "./TotalPrice.styles";
+
+const index = () => {
+  return (
+    <Styled.TotalPriceWrapper>
+      <h3>총 결제 금액</h3>
+      <Styled.ItemPriceWrapper>
+        <span>₩</span>
+        <Styled.ItemPrice>39,000</Styled.ItemPrice>
+      </Styled.ItemPriceWrapper>
+    </Styled.TotalPriceWrapper>
+  );
+};
+
+export default index;

--- a/src/pages/MyPage/MyOrder/MyOrder.styles.ts
+++ b/src/pages/MyPage/MyOrder/MyOrder.styles.ts
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 
-export const Container = styled.div`
+export const MyOrderContainer = styled.div`
   position: relative;
 
   padding: 3.19rem 12.5rem 3.18rem 12.5rem;

--- a/src/pages/MyPage/MyOrder/index.tsx
+++ b/src/pages/MyPage/MyOrder/index.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import Header from "../../../components/MyPage/MyOrder/Header/index";
+import ItemList from "../../../components/MyPage/MyOrder/MyOrderList/index";
+import * as Styled from "./MyOrder.styles";
+
+const index = () => {
+  return (
+    <Styled.MyOrderContainer>
+      <Header />
+      <ItemList />
+    </Styled.MyOrderContainer>
+  );
+};
+
+export default index;

--- a/src/pages/MyPage/MyPage.styles.ts
+++ b/src/pages/MyPage/MyPage.styles.ts
@@ -1,0 +1,12 @@
+import styled from "@emotion/styled";
+
+export const Container = styled.div`
+  position: relative;
+
+  margin: 3.19rem 12.5rem 3.18rem 12.5rem;
+  color: #222;
+
+  font-style: normal;
+  line-height: normal;
+  letter-spacing: -0.04375rem;
+`;

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -1,5 +1,14 @@
+import MyList from "../../components/MyPage/MyList/index";
+import Header from "../../components/MyPage/Header/index";
+import * as Styled from "./MyPage.styles";
+
 const MyPage = () => {
-  return <h1>마이 페이지</h1>;
+  return (
+    <Styled.Container>
+      <Header />
+      <MyList />
+    </Styled.Container>
+  );
 };
 
 export default MyPage;

--- a/src/pages/Payment/Payment.styles.ts
+++ b/src/pages/Payment/Payment.styles.ts
@@ -3,7 +3,7 @@ import styled from "@emotion/styled";
 export const Container = styled.div`
   position: relative;
 
-  margin: 3.19rem 12.5rem 3.18rem 12.5rem;
+  padding: 3.19rem 12.5rem 3.18rem 12.5rem;
   color: #222;
 
   font-style: normal;

--- a/src/pages/Payment/Payment.styles.ts
+++ b/src/pages/Payment/Payment.styles.ts
@@ -1,0 +1,12 @@
+import styled from "@emotion/styled";
+
+export const Container = styled.div`
+  position: relative;
+
+  margin: 3.19rem 12.5rem 3.18rem 12.5rem;
+  color: #222;
+
+  font-style: normal;
+  line-height: normal;
+  letter-spacing: -0.04375rem;
+`;

--- a/src/pages/Payment/index.tsx
+++ b/src/pages/Payment/index.tsx
@@ -1,5 +1,18 @@
+import ItemList from "../../components/Payment/ItemList/index";
+import TotalPrice from "../../components/Payment/TotalPrice/index";
+import TermsAndConditions from "../../components/Payment/TermsAndConditions/index";
+import Btn from "../../components/Payment/Btn/index";
+import * as Styled from "./Payment.styles";
+
 const Payment = () => {
-  return <h1>결제 페이지</h1>;
+  return (
+    <Styled.Container>
+      <ItemList />
+      <TotalPrice />
+      <TermsAndConditions />
+      <Btn />
+    </Styled.Container>
+  );
 };
 
 export default Payment;

--- a/src/pages/Signup/index.tsx
+++ b/src/pages/Signup/index.tsx
@@ -36,7 +36,7 @@ const Signup = () => {
             })}
             <Styled.SigninButton type="submit">회원가입</Styled.SigninButton>
           </Styled.SignForm>
-          <Styled.SigninOutButton>돌아가기</Styled.SigninOutButton>
+          <Styled.SigninOutButton></Styled.SigninOutButton>
         </Styled.SigninMotionDiv>
       </Styled.SigninBox>
     </Styled.Container>


### PR DESCRIPTION
## Issue Number
closes #11 

## ETC

### 결제내역페이지 경로
결제내역페이지(myorder)의 경우 마이페이지에서 진입 가능하므로 경로는 /mypage/myorder로 설정하였습니다.
이에 따라 **App.tsx 파일**도 경로 추가로 인한 내용 변경이 된 점 참고부탁드립니다.

### 작업 화면
<img width="1418" alt="image" src="https://github.com/Yanolza-Miniproject/frontend/assets/139189610/9073dcbc-8739-49eb-a044-be09cbd7bb99">
<img width="1426" alt="image" src="https://github.com/Yanolza-Miniproject/frontend/assets/139189610/4f2d1b3b-f48f-4023-967d-d1c7eea54d2a">
<img width="1423" alt="image" src="https://github.com/Yanolza-Miniproject/frontend/assets/139189610/8006cf6a-f338-47c2-a5c9-2b84b46e9692">



### 이 후 예정 작업
해당 PR의 경우 디자인 작업만 진행된 부분입니다.
머지 후 목업데이터 반영, 무한스크롤 등의 추가 작업 진행할 예정입니다.

피드백 주실 부분 있으시다면 말씀 부탁드립니다!! 감사합니다 